### PR TITLE
Add sweeting.me/blog to webring

### DIFF
--- a/sites.js
+++ b/sites.js
@@ -16,6 +16,7 @@ const sites = [
 	{ url: 'https://sequential.me', title: 'Winston Smith', author: 'Winston Smith' },
   	{ url: 'https://chatha-sphere.github.io/about', title: 'pchatha', author: 'Prayag (Nikku) Chatha' },
 	{ url: 'https://lukeburns.com', title: 'lukeburns', author: 'Luke Burns' },
+        { url: 'https://docs.sweeting.me/s/blog', title: 'thesquash', author: 'Nick Sweeting' },
 ]
 
 export default sites


### PR DESCRIPTION
I love this idea <3

The rc webring link is added in 2 places to my blog, the "related sites" section under "about", and the footer at the very bottom.